### PR TITLE
Add a module build-specific view of /components

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -21,6 +21,11 @@ const routes: Routes = [
     pathMatch: 'full'
   },
   {
+    path: 'module/:id/components',
+    component: ModuleComponentsComponent,
+    pathMatch: 'full'
+  },
+  {
     path: '',
     redirectTo: '/modules',
     pathMatch: 'full'

--- a/src/app/mbs/module-components/module-components.component.ts
+++ b/src/app/mbs/module-components/module-components.component.ts
@@ -16,6 +16,7 @@ export class ModuleComponentsComponent extends BaseListComponent implements OnIn
 
   readonly kojiUrl: string = environment.kojiUrl;
   components: Array<MbsComponent> = [];
+  moduleId = 0;
 
   constructor(private route: ActivatedRoute,
               private moduleService: ModuleService) { super(); }
@@ -26,6 +27,7 @@ export class ModuleComponentsComponent extends BaseListComponent implements OnIn
       this.components = [];
       this.exhausted = false;
       this.currentPage = 1;
+      this.moduleId = this.route.snapshot.params.id;
       this.getComponents();
     });
   }
@@ -33,7 +35,7 @@ export class ModuleComponentsComponent extends BaseListComponent implements OnIn
   getComponents(): void {
     if (!this.exhausted && !this.loading) {
       this.loading = true;
-      this.moduleService.getComponents(this.currentPage, this.orderBy, this.orderDirection).subscribe(
+      this.moduleService.getComponents(this.currentPage, this.orderBy, this.orderDirection, this.moduleId).subscribe(
         data => {
           if (data.items.length) {
             this.components = this.components.concat(data.items);

--- a/src/app/mbs/module-detail/module-detail.component.html
+++ b/src/app/mbs/module-detail/module-detail.component.html
@@ -28,7 +28,11 @@
     <tbody>
       <tr>
         <td scope="row">Components</td>
-        <td scope="row">{{ num_built_components }}/{{ num_components }} complete</td>
+        <td scope="row">
+          <a [routerLink]="['/module', module.id, 'components']">
+            {{ num_built_components }}/{{ num_components }} complete
+          </a>
+	</td>
       </tr>
       <tr>
         <td scope="row">Context</td>

--- a/src/app/mbs/services/module.service.ts
+++ b/src/app/mbs/services/module.service.ts
@@ -30,9 +30,13 @@ export class ModuleService {
     return this.http.get<MbsModule>(this.mbsUrl + 'module-builds/' + id);
   }
 
-  getComponents(page: number = 1, orderBy: string = 'id', orderDirection: string = 'desc'): Observable<MbsComponentsApi> {
+  getComponents(page: number = 1, orderBy: string = 'id', orderDirection: string = 'desc', moduleId: number = 0):
+      Observable<MbsComponentsApi> {
     const orderKey = this.getOrderKey(orderDirection);
-    const url = this.mbsUrl + 'component-builds/?per_page=40&page=' + page + '&' + orderKey + '=' + orderBy;
+    let url = this.mbsUrl + 'component-builds/?per_page=40&page=' + page + '&' + orderKey + '=' + orderBy;
+    if (moduleId > 0) {
+      url = url + '&module_id=' + moduleId;
+    }
     return this.http.get<MbsComponentsApi>(url);
   }
 


### PR DESCRIPTION
A new link on /module/<id> allows clicking through to a new view
at /module/<id>/components which shows only components for the
module build with the given ID

Signed-off-by: Mat Booth <mat.booth@redhat.com>