### PR TITLE
WIP: Add scratch build status to UI

### DIFF
--- a/src/app/mbs/models/mbs.type.ts
+++ b/src/app/mbs/models/mbs.type.ts
@@ -18,6 +18,7 @@ export interface MbsModuleShort {
     context?: string;
     id: number;
     name: string;
+    scratch?: boolean;
     state: number;
     state_name: string;
     stream: string;

--- a/src/app/mbs/module-detail/module-detail.component.html
+++ b/src/app/mbs/module-detail/module-detail.component.html
@@ -71,6 +71,10 @@
         <td scope="row">{{ module.rebuild_strategy }}</td>
       </tr>
       <tr>
+        <td scope="row">Scratch</td>
+        <td scope="row">{{ module.scratch }}</td>
+      </tr>
+      <tr>
         <td scope="row">State</td>
         <td scope="row">
           {{ module.state_name.toUpperCase().charAt(0) + module.state_name.slice(1) }}

--- a/src/app/mbs/modules/modules.component.html
+++ b/src/app/mbs/modules/modules.component.html
@@ -3,7 +3,7 @@
 <table class="table table-responsive-sm table-hover table-bordered mbs-list-table" infinite-scroll (scrolled)="onScrollDown()">
   <thead>
     <tr>
-      <th *ngFor="let header of ['ID', 'Name', 'Stream', 'Version', 'Context', 'State']"
+      <th *ngFor="let header of ['ID', 'Name', 'Stream', 'Version', 'Context', 'Scratch', 'State']"
           [attr.id]="header.toLowerCase() + 'Header'" scope="col">
         <a *ngIf="header != 'Context'" [routerLink]="['/modules', {'orderBy': header.toLowerCase(), 'orderDirection': getOrderDirection(header)}]"
             [ngClass]="getArrowClass(header)">
@@ -22,6 +22,7 @@
       <td scope="row">{{ module.stream }}</td>
       <td scope="row">{{ module.version }}</td>
       <td *ngIf="module.context !== undefined" scope="row" class="context">{{ module.context }}</td>
+      <td scope="row">{{ module.scratch ? 'Yes' : 'No' }}</td>
       <td class="{{ getStateCssClass(module) }}" scope="row">
         {{ module.state_name.toUpperCase().charAt(0) + module.state_name.slice(1) }}
       </td>


### PR DESCRIPTION
This is an initial attempt at identifying scratch module builds in the MBS web UI.

However, rather than adding a whole new column to the Modules page, would it be cleaner to append "(scratch)" or some identifying character (such as "#") to the text in one of the existing columns? Or italicize the rows for scratch builds?

Feedback and thoughts are welcomed.