### PR TITLE
Alternate add scratch build status to UI

### DIFF
--- a/src/app/mbs/models/mbs.type.ts
+++ b/src/app/mbs/models/mbs.type.ts
@@ -18,6 +18,7 @@ export interface MbsModuleShort {
     context?: string;
     id: number;
     name: string;
+    scratch?: boolean;
     state: number;
     state_name: string;
     stream: string;

--- a/src/app/mbs/module-detail/module-detail.component.html
+++ b/src/app/mbs/module-detail/module-detail.component.html
@@ -71,6 +71,10 @@
         <td scope="row">{{ module.rebuild_strategy }}</td>
       </tr>
       <tr>
+        <td scope="row">Scratch</td>
+        <td scope="row">{{ module.scratch ? 'Yes' : 'No' }}</td>
+      </tr>
+      <tr>
         <td scope="row">State</td>
         <td scope="row">
           {{ module.state_name.toUpperCase().charAt(0) + module.state_name.slice(1) }}

--- a/src/app/mbs/modules/modules.component.html
+++ b/src/app/mbs/modules/modules.component.html
@@ -18,7 +18,7 @@
   <tbody>
     <tr *ngFor="let module of modules">
       <td scope="row"><a [routerLink]="['/module', module.id]">{{ module.id }}</a></td>
-      <td scope="row">{{ module.name }}</td>
+      <td scope="row">{{ module.name + (module.scratch ? ' (scratch)' : '') }}</td>
       <td scope="row">{{ module.stream }}</td>
       <td scope="row">{{ module.version }}</td>
       <td *ngIf="module.context !== undefined" scope="row" class="context">{{ module.context }}</td>


### PR DESCRIPTION
Alternate version of PR #9 that appends " (scratch)" to the names of scratch module builds, rather than adding a separate `Scratch` column with `Yes`/`No` values.

It's not much to look at right now since there aren't any scratch module builds yet.