### PR TITLE
Stop build tracker animation in module detail view for completed scratch builds

### DIFF
--- a/src/app/mbs/module-detail/module-detail.component.html
+++ b/src/app/mbs/module-detail/module-detail.component.html
@@ -14,7 +14,10 @@
     <li [ngClass]="{'build-tracker-step-done': module.state > 0, 'build-tracker-step-active': module.state == 0}">Init</li>
     <li [ngClass]="{'build-tracker-step-done': module.state > 1, 'build-tracker-step-active': module.state == 1}">Wait</li>
     <li [ngClass]="{'build-tracker-step-done': module.state > 2, 'build-tracker-step-active': module.state == 2}">Build</li>
-    <li [ngClass]="{'build-tracker-step-done': module.state > 3, 'build-tracker-step-active': module.state == 3}">Done</li>
+    <li [ngClass]="{
+        'build-tracker-step-done': module.state > 3 || (module.state == 3 && module.scratch),
+        'build-tracker-step-active': module.state == 3 && !module.scratch
+    }">Done</li>
     <li [ngClass]="{'build-tracker-step-done': module.state >= 4}">Ready</li>
   </ul>
 


### PR DESCRIPTION
This avoids having the module detail page show a pulsing "Done" for completed scratch modules--since they never go to the "Ready" state